### PR TITLE
fix: update retrieveCard helper

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -77,7 +77,7 @@
     "@types/passport": "1.0.0",
     "@types/request": "^2.48.1",
     "@types/socket.io": "^2.1.2",
-    "@types/stripe": "6.30.5",
+    "@types/stripe": "6.31.4",
     "husky": "2.7.0",
     "jest": "24.8.0",
     "mockingoose": "^2.13.1",

--- a/api/server/stripe.ts
+++ b/api/server/stripe.ts
@@ -46,7 +46,7 @@ function cancelSubscription({ subscriptionId }) {
 function retrieveCard({ customerId, cardId }) {
   logger.debug(customerId);
   logger.debug(cardId);
-  return stripeInstance.customers.retrieveCard(customerId, cardId);
+  return stripeInstance.customers.retrieveSource(customerId, cardId);
 }
 
 function createNewCard({ customerId, token }) {

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -143,6 +143,10 @@
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
   integrity sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==
+  dependencies:
+    "@jest/source-map" "^24.3.0"
+    chalk "^2.0.1"
+    slash "^2.0.0"
 
 "@jest/core@^24.8.0":
   version "24.8.0"
@@ -531,10 +535,10 @@
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
 
-"@types/stripe@6.30.5":
-  version "6.30.5"
-  resolved "https://registry.yarnpkg.com/@types/stripe/-/stripe-6.30.5.tgz#89c274a51c443a1698a4cacc363f88313102f101"
-  integrity sha512-1PMVuZMCvOj7mI+ZpsqU5XpwSL3nXy90S2cs4GlMn8CCkvy8HlpG1B1VY2A1QWqaXqj4nVpvrquqv37p1nsMyw==
+"@types/stripe@6.31.4":
+  version "6.31.4"
+  resolved "https://registry.yarnpkg.com/@types/stripe/-/stripe-6.31.4.tgz#ea69a539fa06f155eb9b9b00b2b17cfbd092db70"
+  integrity sha512-u9eNG6XZmh7xSO92hCWPmbu5IF/lp4CfJ2t0kXW5/AcF/5TrEQTMmomPS84+5xRFXh73W2RXmZCGM8XGa7jiSw==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
Fixes issue #43 

What was done:

* Update @types/stripe (these types are still inaccurate, an PR in that repo is necessary)
* Change retrieveCard helper; it now uses the retrieveSource function from the stripe package