### PR TITLE
fix: subscribe to post events when switching discussion

### DIFF
--- a/saas/app/pages/discussion.tsx
+++ b/saas/app/pages/discussion.tsx
@@ -90,6 +90,8 @@ function DiscussionPageCompFunctional({
       if (discussion) {
         discussion.joinSocketRooms();
       }
+      
+      store.socket.on('postEvent', handlePostEvent);
     }
 
     return () => {


### PR DESCRIPTION
otherwise it doesn't handle post events on discussion pages any others than initial one until manual page refresh