### PR TITLE
Fix a bug where the avatars don't get edited

### DIFF
--- a/saas/app/pages/team-settings.tsx
+++ b/saas/app/pages/team-settings.tsx
@@ -109,7 +109,7 @@ function TeamSettings({ store, isMobile, firstGridItem, teamRequired, teamSlug }
 
       await currentTeam.updateTheme({
         name: newName,
-        avatarUrl: newAvatarUrl,
+        avatarUrl: responseFromApiServerForUpload.url,
       });
 
       notify('You successfully uploaded new Team logo.');

--- a/saas/app/pages/your-settings.tsx
+++ b/saas/app/pages/your-settings.tsx
@@ -114,7 +114,7 @@ function YourSettings({ store, isMobile, firstGridItem, teamRequired }: Props) {
 
       await currentUser.updateProfile({
         name: newName,
-        avatarUrl: newAvatarUrl,
+        avatarUrl: responseFromApiServerForUpload.url,
       });
 
       notify('You successfully uploaded new avatar.');


### PR DESCRIPTION
Hi,
the form to edit a user or team avatar seemed to be buggy,
orignally useState was used, but since the setNewAvatarUrl method does not have an immediate effect on newAvatarUrl, and newAvatarUrl was originally set to the existing avatar, the avatars where not modified.
