### PR TITLE
Add missing textField's textHelper in MemberChooser component(s)

### DIFF
--- a/book/10-begin/app/components/common/MemberChooser.tsx
+++ b/book/10-begin/app/components/common/MemberChooser.tsx
@@ -55,6 +55,7 @@ class MemberChooser extends React.Component<Props, State> {
             variant="standard"
             label="Find team member by name"
             placeholder="Select participants"
+            helperText={this.props.helperText}
           />
         )}
         onChange={this.handleChange}

--- a/book/10-end-functional/app/components/common/MemberChooser.tsx
+++ b/book/10-end-functional/app/components/common/MemberChooser.tsx
@@ -55,6 +55,7 @@ class MemberChooser extends React.Component<Props, State> {
             variant="standard"
             label="Find team member by name"
             placeholder="Select participants"
+            helperText={this.props.helperText}
           />
         )}
         onChange={this.handleChange}

--- a/book/10-end/app/components/common/MemberChooser.tsx
+++ b/book/10-end/app/components/common/MemberChooser.tsx
@@ -55,6 +55,7 @@ class MemberChooser extends React.Component<Props, State> {
             variant="standard"
             label="Find team member by name"
             placeholder="Select participants"
+            helperText={this.props.helperText}
           />
         )}
         onChange={this.handleChange}

--- a/book/8-end/app/components/common/MemberChooser.tsx
+++ b/book/8-end/app/components/common/MemberChooser.tsx
@@ -55,6 +55,7 @@ class MemberChooser extends React.Component<Props, State> {
             variant="standard"
             label="Find team member by name"
             placeholder="Select participants"
+            helperText={this.props.helperText}
           />
         )}
         onChange={this.handleChange}

--- a/book/9-begin/app/components/common/MemberChooser.tsx
+++ b/book/9-begin/app/components/common/MemberChooser.tsx
@@ -55,6 +55,7 @@ class MemberChooser extends React.Component<Props, State> {
             variant="standard"
             label="Find team member by name"
             placeholder="Select participants"
+            helperText={this.props.helperText}
           />
         )}
         onChange={this.handleChange}

--- a/book/9-end/app/components/common/MemberChooser.tsx
+++ b/book/9-end/app/components/common/MemberChooser.tsx
@@ -55,6 +55,7 @@ class MemberChooser extends React.Component<Props, State> {
             variant="standard"
             label="Find team member by name"
             placeholder="Select participants"
+            helperText={this.props.helperText}
           />
         )}
         onChange={this.handleChange}

--- a/saas/app/components/common/MemberChooser.tsx
+++ b/saas/app/components/common/MemberChooser.tsx
@@ -55,6 +55,7 @@ class MemberChooser extends React.Component<Props, State> {
             variant="standard"
             label="Find team member by name"
             placeholder="Select participants"
+            helperText={this.props.helperText}
           />
         )}
         onChange={this.handleChange}


### PR DESCRIPTION
Hi,
I noticed the textHelper props from MemberChooser wasn't passed to its TextField child so it wasn't displayed, so I added it :)