### PR TITLE
Minor typo: Trailing comma in JSON

### DIFF
--- a/saas/api/tsconfig.json
+++ b/saas/api/tsconfig.json
@@ -19,7 +19,7 @@
     "lib": ["es2020"],
     "module": "commonjs",
     "outDir": "production-server/",
-    "downlevelIteration": true,
+    "downlevelIteration": true
   },
   "include": ["./server/**/*.ts"]
 }


### PR DESCRIPTION
This file is invalid JSON because of a trailing comma.